### PR TITLE
Feature/F85-L-25 아이템 카드 박스 로딩 과정에 스켈레톤 UI 추가

### DIFF
--- a/myapp/src/components/Links/ItemCardContainer/ItemCardContainer.tsx
+++ b/myapp/src/components/Links/ItemCardContainer/ItemCardContainer.tsx
@@ -1,7 +1,15 @@
 import ItemCard from '../ItemCard/ItemCard';
-import { ItemCardGrid, NoLink } from './ItemCardContainerStyle';
+import { ItemCardGrid } from './ItemCardContainerStyle';
 import { ItemLinks } from '../../../types/linkTypes';
 import Pagination from '../Pagination/Pagination';
+import {
+  SkeletonCardContainer,
+  SkeletonCardCreatedAt,
+  SkeletonCardDescription,
+  SkeletonCardInfoBox,
+  SkeletonCardTimeDiff,
+} from './SkeletonCardStyle';
+
 interface PropsType {
   linkListInfo: ItemLinks;
   isLoading: boolean;
@@ -22,11 +30,25 @@ function ItemCardContainer({
   setCurrentPage,
 }: PropsType) {
   if (isLoading) {
-    return <div>loading...</div>;
+    return (
+      <ItemCardGrid>
+        {Array.from(
+          { length: pageSize },
+          (_, i) =>
+            i <= pageSize && (
+              <SkeletonCardContainer>
+                <SkeletonCardInfoBox>
+                  <SkeletonCardTimeDiff />
+                  <SkeletonCardDescription />
+                  <SkeletonCardCreatedAt />
+                </SkeletonCardInfoBox>
+              </SkeletonCardContainer>
+            )
+        )}
+      </ItemCardGrid>
+    );
   }
-  if (linkListInfo.list.length <= 0) {
-    return <NoLink>저장된 링크가 없습니다</NoLink>;
-  }
+
   return (
     <>
       <ItemCardGrid>

--- a/myapp/src/components/Links/ItemCardContainer/SkeletonCardStyle.ts
+++ b/myapp/src/components/Links/ItemCardContainer/SkeletonCardStyle.ts
@@ -1,0 +1,86 @@
+import styled, { keyframes } from 'styled-components';
+import { BREAKPOINTS } from '../../../constatnts/Breakpoint';
+
+const loadingAnimation = keyframes`
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+`;
+
+export const SkeletonCardContainer = styled.div`
+  width: 32.5rem;
+  height: 32.7rem;
+  background-color: var(--gray30);
+  border-radius: 15px;
+  position: relative;
+  box-shadow: 0 5px 25px 0 rgba(0, 0, 0, 0.08);
+  @media screen and (max-width: ${BREAKPOINTS.largeDesktop}) and (min-width: ${BREAKPOINTS.tablet}) {
+    width: 34rem;
+    height: 33.4rem;
+  }
+  @media screen and (min-width: ${BREAKPOINTS.largeDesktop}) {
+    width: 34rem;
+    height: 33.4rem;
+  }
+`;
+
+export const SkeletonCardInfoBox = styled.div`
+  background-color: var(--gray10);
+  border-radius: 0 0 15px 15px;
+  width: 32.5rem;
+  height: 13.5rem;
+  position: absolute;
+  bottom: 0;
+  @media screen and (max-width: ${BREAKPOINTS.largeDesktop}) and (min-width: ${BREAKPOINTS.tablet}) {
+    width: 34rem;
+  }
+  @media screen and (min-width: ${BREAKPOINTS.largeDesktop}) {
+    width: 34rem;
+  }
+`;
+export const SkeletonCardTimeDiff = styled.div`
+  width: 8.8rem;
+  height: 1.6rem;
+  position: absolute;
+  bottom: 10.3rem;
+  left: 2rem;
+  border-radius: 5px;
+  background: linear-gradient(90deg, var(--gray30) 0%, var(--gray40) 10%, var(--gray30) 60%);
+  background-size: 200% 100%;
+  animation: ${loadingAnimation} 2s infinite;
+`;
+export const SkeletonCardDescription = styled.div`
+  width: 28.5rem;
+  height: 4rem;
+  background-color: var(--gray30);
+  position: absolute;
+  bottom: 4.4rem;
+  left: 2rem;
+  border-radius: 5px;
+  background: linear-gradient(90deg, var(--gray30) 0%, var(--gray40) 10%, var(--gray30) 60%);
+  background-size: 200% 100%;
+  animation: ${loadingAnimation} 2s infinite;
+  @media screen and (max-width: ${BREAKPOINTS.largeDesktop}) and (min-width: ${BREAKPOINTS.tablet}) {
+    width: 30rem;
+    height: 4.9rem;
+  }
+  @media screen and (min-width: ${BREAKPOINTS.largeDesktop}) {
+    width: 30rem;
+    height: 4.9rem;
+  }
+`;
+export const SkeletonCardCreatedAt = styled.div`
+  width: 7rem;
+  height: 1.6rem;
+  background-color: var(--gray30);
+  position: absolute;
+  bottom: 1.5rem;
+  left: 2rem;
+  border-radius: 5px;
+  background: linear-gradient(90deg, var(--gray30) 0%, var(--gray40) 10%, var(--gray30) 60%);
+  background-size: 200% 100%;
+  animation: ${loadingAnimation} 2s infinite;
+`;


### PR DESCRIPTION
# 작업분류

- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## ✏️ 작업 내용 요약
> 스켈레톤 UI를 적용하여 콘텐츠 로딩 전 사용자에게 빈 화면 대신 로딩 중임을 시각적으로 안내합니다.

## 📝 작업 내용 설명
![image (7)](https://github.com/user-attachments/assets/8837b7f2-a6c9-46c5-bf8b-6053d5659e90)
> API 응답 속도가 느린 경우 사용자 경험을 개선하기 위해 아이템 카드 박스 로딩 과정에 스켈레톤 UI를 추가하였습니다.


## 📷 스크린샷 (선택)
![스켈레톤UI](https://github.com/user-attachments/assets/84d10dcd-23b1-40ee-b865-ed71d15ba212)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
